### PR TITLE
Fix pointer cast in ValueTreeWrapper

### DIFF
--- a/Source/Utility/ValueTreeWrapper.h
+++ b/Source/Utility/ValueTreeWrapper.h
@@ -137,7 +137,7 @@ protected:
     {
         //TODO: this is probably something we want, but also this means we can't use any "trigger"-like functions in initValueTree (), e.g, RuntimeRootProperties::triggerAppResumed ()
         //jassert (data.hasProperty (property));
-        return (juce::int64) data.getProperty (property);
+        return reinterpret_cast<T> (static_cast<juce::int64> (data.getProperty (property)));
     }
 
     // non-pointer version


### PR DESCRIPTION
## Summary
- fix return type cast for pointer-specialization of `getValue`

## Testing
- `echo "no tests"`